### PR TITLE
Fix link to specification

### DIFF
--- a/src/SarifWeb/Views/Home/Index.cshtml
+++ b/src/SarifWeb/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
     </div>
     <div id="specSectionButtons">
         <div id="specSectionButtons1">
-            <button id="specSectionButtonRead" role="button" href="https://github.com/oasis-tcs/sarif-spec/tree/master/Documents/CommitteeSpecificationDrafts/CSD.1" target="_blank" class="content-button sarifweb-button gray-section">Read the specification</button>
+            <button id="specSectionButtonRead" role="button" href="https://github.com/oasis-tcs/sarif-spec/tree/master/Documents/CommitteeSpecificationDrafts" target="_blank" class="content-button sarifweb-button gray-section">Read the specification</button>
             <button id="specSectionButtonAsk" role="button" href="https://github.com/oasis-tcs/sarif-spec/issues/new" target="_blank" class="content-button sarifweb-button gray-section">Ask a question</button>
         </div>
         <div id="specSectionButtons2">


### PR DESCRIPTION
Fix the link to specification. 

Also link to `https://github.com/oasis-tcs/sarif-spec/tree/master/Documents/CommitteeSpecificationDrafts` instead of a specific version like `https://github.com/oasis-tcs/sarif-spec/tree/master/Documents/CommitteeSpecificationDrafts/v2.0-CSD.1`