### PR TITLE
Fix #95: Upgrade to latest SDK

### DIFF
--- a/src/SarifWeb/BuildScripts/Copy-Sarif.Multitool.ps1
+++ b/src/SarifWeb/BuildScripts/Copy-Sarif.Multitool.ps1
@@ -17,6 +17,8 @@ $ErrorActionPreference = "Stop"
 
 $ToolPackageName = "Sarif.Multitool"
 $SdkPackageName = "Sarif.Sdk"
+$SourceSarifSchemaFileName = "sarif-2.1.0-rtm.4.json"
+$DestinationSarifSchemaFileName = "sarif-schema.json"
 
 $PackagesRoot = Join-Path -Resolve $PSScriptRoot ..\..\packages
 if (-not (Test-Path $PackagesRoot)) {
@@ -64,9 +66,10 @@ Write-Verbose "Copying $ToolPackageName binaries from $toolBinariesSourcePath to
 Copy-Item -Recurse -Path $toolBinariesSourcePath -Destination $DestinationPath
 
 $sdkPackagePath = Get-PackagePath $SdkPackageName
-$sarifSchemaPath = "$sdkPackagePath\Schemata\sarif-schema.json"
+$sourceSarifSchemaPath = "$sdkPackagePath\Schemata\$SourceSarifSchemaFileName"
+$destinationSarifSchemaPath = "$DestinationPath\$DestinationSarifSchemaFileName"
 
-Write-Verbose "Copying SARIF schema file from $sarifSchemaPath to ${DestinationPath}..."
-Copy-Item -Path $sarifSchemaPath -Destination $DestinationPath
+Write-Verbose "Copying SARIF schema file from $sourceSarifSchemaPath to ${destinationSarifSchemaPath}..."
+Copy-Item -Path $sourceSarifSchemaPath -Destination $destinationSarifSchemaPath
 
 Write-Verbose "Done."

--- a/src/SarifWeb/SarifWeb.csproj
+++ b/src/SarifWeb/SarifWeb.csproj
@@ -82,8 +82,8 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sarif, Version=2.1.0.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Sdk.2.1.0-rtm.0\lib\net461\Sarif.dll</HintPath>
+    <Reference Include="Sarif, Version=2.1.14.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.2.1.14\lib\net461\Sarif.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SarifWeb/Views/Home/Index.cshtml
+++ b/src/SarifWeb/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
     </div>
     <div id="specSectionButtons">
         <div id="specSectionButtons1">
-            <button id="specSectionButtonRead" role="button" href="https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.pdf" target="_blank" class="content-button sarifweb-button gray-section">Read the specification</button>
+            <button id="specSectionButtonRead" role="button" href="https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/" target="_blank" class="content-button sarifweb-button gray-section">Read the specification</button>
             <button id="specSectionButtonAsk" role="button" href="https://github.com/oasis-tcs/sarif-spec/issues/new" target="_blank" class="content-button sarifweb-button gray-section">Ask a question</button>
         </div>
         <div id="specSectionButtons2">

--- a/src/SarifWeb/Views/Home/Index.cshtml
+++ b/src/SarifWeb/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
     </div>
     <div id="specSectionButtons">
         <div id="specSectionButtons1">
-            <button id="specSectionButtonRead" role="button" href="https://github.com/oasis-tcs/sarif-spec/tree/master/Documents/CommitteeSpecificationDrafts/CSD.1" target="_blank" class="content-button sarifweb-button gray-section">Read the specification</button>
+            <button id="specSectionButtonRead" role="button" href="https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.pdf" target="_blank" class="content-button sarifweb-button gray-section">Read the specification</button>
             <button id="specSectionButtonAsk" role="button" href="https://github.com/oasis-tcs/sarif-spec/issues/new" target="_blank" class="content-button sarifweb-button gray-section">Ask a question</button>
         </div>
         <div id="specSectionButtons2">

--- a/src/SarifWeb/packages.config
+++ b/src/SarifWeb/packages.config
@@ -30,8 +30,8 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="popper.js" version="1.14.0" targetFramework="net461" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
-  <package id="Sarif.Multitool" version="2.1.0-rtm.0" targetFramework="net461" />
-  <package id="Sarif.Sdk" version="2.1.0-rtm.0" targetFramework="net461" />
+  <package id="Sarif.Multitool" version="2.1.14" targetFramework="net461" />
+  <package id="Sarif.Sdk" version="2.1.14" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net461" />
   <package id="WebGrease" version="1.5.2" targetFramework="net452" />


### PR DESCRIPTION
This upgrades the web site to the latest version of the SARIF SDK, which fixes a bug that was first discovered by @simmse in the SARIF Viewer VSIX for Visual Studio (Microsoft/sarif-visualstudio-extension#85).

Also:
- Per suggestion from @pascalberger, Update the specification link to point to the final OASIS Committee Specification.