### PR TITLE
Fix #108: Update with links to Python OM and tutorials

### DIFF
--- a/src/SarifWeb/Content/Home.css
+++ b/src/SarifWeb/Content/Home.css
@@ -130,7 +130,12 @@
 }
 
 #specSectionButtonRead {
-    height: 120px;
+    height: 58px;
+    width: 300px;
+}
+
+#specSectionButtonTutorials {
+    height: 58px;
     width: 300px;
 }
 

--- a/src/SarifWeb/Views/Home/Index.cshtml
+++ b/src/SarifWeb/Views/Home/Index.cshtml
@@ -24,7 +24,7 @@
 
 <section id="specSection" role="region" aria-labelledby="specSectionTitle" class="content-section white-section">
     <a name="Specification"></a>
-    <div id="specSectionTitle" role="heading" aria-level="2" class="content-section-title">Specification</div>
+    <div id="specSectionTitle" role="heading" aria-level="2" class="content-section-title">Specification and documentation</div>
     <div class="content-section-text content-section-description">
         The <b>Static Analysis Results Interchange Format (SARIF)</b> is an
         <a href="https://www.oasis-open.org/" target="_blank" class="strong-link">OASIS</a> <a href="https://www.oasis-open.org/news/announcements/static-analysis-results-interchange-format-sarif-v2-1-0-from-the-sarif-tc-is-an-a" target="_blank" class="strong-link">Committee Specification</a>. The information and tools
@@ -33,6 +33,7 @@
     <div id="specSectionButtons">
         <div id="specSectionButtons1">
             <button id="specSectionButtonRead" role="button" href="https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/" target="_blank" class="content-button sarifweb-button gray-section">Read the specification</button>
+            <button id="specSectionButtonTutorials" role="button" href="https://github.com/microsoft/sarif-tutorials" target="_blank" class="content-button sarifweb-button gray-section">Study the tutorials</button>
             <button id="specSectionButtonAsk" role="button" href="https://github.com/oasis-tcs/sarif-spec/issues/new" target="_blank" class="content-button sarifweb-button gray-section">Ask a question</button>
         </div>
         <div id="specSectionButtons2">
@@ -186,7 +187,10 @@
                         </svg>
                     </div>
                 </div>
-                <div class="tools-item-description tools-other-item-description">Coming soon.</div>
+                <div class="tools-item-description tools-other-item-description">
+                    Python classes for the SARIF object model in <a href="https://github.com/microsoft/sarif-python-om">source form</a>
+                    and as a downloadable <a href="https://pypi.org/project/sarif-om">Python module</a>.
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The **Specification** section at the top is now titled **Specification and documentation**, and contains a new button to ["Study the tutorials"](http://github.com/microsoft/sarif-tutorials):

![image](https://user-images.githubusercontent.com/11762653/66689854-a1050180-ec41-11e9-80e9-243a16cfcd86.png)

The **Python** area of the **Tools and libraries** section, for so long "Coming soon", has now come, and links to the Python OM [repo](https://github.com/microsoft/sarif-python-om) and [downloadable module](https://pypi.org/project/sarif-om):

![image](https://user-images.githubusercontent.com/11762653/66689926-0953e300-ec42-11e9-87df-341e95269b55.png)

It's not beautiful -- feel free to sic a web designer on it, which I'm not -- but let's get this merged first, and prettied up later or never.