### PR TITLE
Display the correct branding for GitHub Advanced Security code scanning.

### DIFF
--- a/src/SarifWeb/BuildScripts/Copy-Sarif.Multitool.ps1
+++ b/src/SarifWeb/BuildScripts/Copy-Sarif.Multitool.ps1
@@ -16,10 +16,11 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $ToolPackageName = "Sarif.Multitool"
+$LibraryPackageName = "Sarif.Multitool.Library"
 $SdkPackageName = "Sarif.Sdk"
 $SourceSarifSchemaFileName = "sarif-2.1.0-rtm.5.json"
 $DestinationSarifSchemaFileName = "sarif-schema.json"
-$GitHubDspConfigurationFileName = "github-dsp.config.xml";
+$GitHubConfigurationFileName = "github.config.xml";
 
 $PackagesRoot = Join-Path -Resolve $PSScriptRoot ..\..\packages
 if (-not (Test-Path $PackagesRoot)) {
@@ -69,14 +70,15 @@ Copy-Item -Recurse -Path $toolBinariesSourcePath -Destination $DestinationPath
 $sdkPackagePath = Get-PackagePath $SdkPackageName
 $sourceSarifSchemaPath = "$sdkPackagePath\Schemata\$SourceSarifSchemaFileName"
 $destinationSarifSchemaPath = "$DestinationPath\$DestinationSarifSchemaFileName"
-$sourceGitHubDspConfigurationFilePath = "$toolPackagePath\policies\$GitHubDspConfigurationFileName"
+$libraryPackagePath = Get-PackagePath $LibraryPackageName
+$sourceGitHubConfigurationFilePath = "$libraryPackagePath\policies\$GitHubConfigurationFileName"
 $policiesDestinationDirectory = "$DestinationPath\policies"
 
 Write-Verbose "Copying SARIF schema file from $sourceSarifSchemaPath to ${destinationSarifSchemaPath}..."
 Copy-Item -Path $sourceSarifSchemaPath -Destination $destinationSarifSchemaPath
 
-Write-Verbose "Copying GitHub DSP rule configuration from $sourceGitHubDspConfigurationFilePath to {$policiesDestinationDirectory}..."
+Write-Verbose "Copying GitHub rule configuration from $sourceGitHubConfigurationFilePath to {$policiesDestinationDirectory}..."
 New-Item -Type Directory $policiesDestinationDirectory | Out-Null
-Copy-Item $sourceGitHubDspConfigurationFilePath  $policiesDestinationDirectory
+Copy-Item $sourceGitHubConfigurationFilePath  $policiesDestinationDirectory
 
 Write-Verbose "Done."

--- a/src/SarifWeb/SarifWeb.csproj
+++ b/src/SarifWeb/SarifWeb.csproj
@@ -82,8 +82,8 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sarif, Version=2.1.14.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Sdk.2.1.14\lib\net461\Sarif.dll</HintPath>
+    <Reference Include="Sarif, Version=2.3.6.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.2.3.6\lib\net461\Sarif.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SarifWeb/Services/ValidationService.cs
+++ b/src/SarifWeb/Services/ValidationService.cs
@@ -49,9 +49,9 @@ namespace SarifWeb.Services
             string inputFilePath = Path.Combine(_postedFilesDirectory, validationRequest.SavedFileName);
             string outputFileName = Path.GetFileNameWithoutExtension(validationRequest.PostedFileName) + ValidationLogSuffix;
             string outputFilePath = Path.Combine(_postedFilesDirectory, outputFileName);
-            string gitHubDspConfigFilePath = Path.Combine(_multitoolDirectory, "policies", "github-dsp.config.xml");
+            string gitHubConfigFilePath = Path.Combine(_multitoolDirectory, "policies", "github.config.xml");
 
-            string arguments = $"validate --output \"{outputFilePath}\" --json-schema \"{_schemaFilePath}\" --force --pretty-print --verbose --config \"{gitHubDspConfigFilePath}\" --rich-return-code \"{inputFilePath}\"";
+            string arguments = $"validate --output \"{outputFilePath}\" --json-schema \"{_schemaFilePath}\" --force --pretty-print --verbose --config \"{gitHubConfigFilePath}\" --rich-return-code \"{inputFilePath}\"";
 
             ValidationResponse validationResponse;
             try

--- a/src/SarifWeb/Views/ValidationUi/Index.cshtml
+++ b/src/SarifWeb/Views/ValidationUi/Index.cshtml
@@ -64,11 +64,11 @@
                     <span class="ui-icon ui-icon-gear">icon</span>
                 </button>
                 <div id="ruleFilters">
-                    <input type="checkbox" id="noteRules" aria-labelledby="noteRulesLabel" title="Rules with level 'note'" disabled />
-                    <label id="noteRulesLabel" for="noteRules" class="ui-widget">note-level rules</label>
+                    <input type="checkbox" id="noteRules" aria-labelledby="noteRulesLabel" title="More ways to improve your SARIF files." disabled />
+                    <label id="noteRulesLabel" for="noteRules" class="ui-widget">Additional suggestions</label>
                     <br />
-                    <input type="checkbox" id="gitHubDspRules" aria-labelledby="gitHubDspRulesLabel" title="Requirements for SARIF files uploaded to the GitHub Developer Security Portal" disabled />
-                    <label id="gitHubDspRulesLabel" for="gitHubDspRules" class="ui-widget">GitHub DSP rules</label>
+                    <input type="checkbox" id="gitHubRules" aria-labelledby="gitHubRulesLabel" title="Requirements for SARIF files uploaded to GitHub Advanced Security code scanning." disabled />
+                    <label id="gitHubRulesLabel" for="gitHubRules" class="ui-widget">GitHub ingestion rules</label>
                 </div>
             </div>
             <ul id="utilitiesMenu">
@@ -152,8 +152,8 @@
 
             let editor = null;
             const $pageBlanket = $("#pageBlanket");
-            const $gitHubDspRules = $("#gitHubDspRules");
-            $gitHubDspRules.change(processValidationLog);
+            const $gitHubRules = $("#gitHubRules");
+            $gitHubRules.change(processValidationLog);
             const $noteRules = $("#noteRules");
             $noteRules.change(processValidationLog);
             let isFileOpening = false;
@@ -312,7 +312,7 @@
                 currentResultLocationIndex = -1;
 
                 const run = validationLog.runs[0];
-                const gitHubDspRulesEnabled = $gitHubDspRules.is(":checked");
+                const gitHubRulesEnabled = $gitHubRules.is(":checked");
                 const noteRulesEnabled = $noteRules.is(":checked");
 
                 if (run.results && run.results.length > 0) {
@@ -320,10 +320,10 @@
                     if (run.tool && run.tool.driver && run.tool.driver.rules) {
                         $.each(run.results, function (index, result) {
                             const rule = run.tool.driver.rules[result.ruleIndex];
-                            const isDsp = isGitHubDspRule(rule);
+                            const isGitHub = isGitHubRule(rule);
                             const isNote = isNoteResult(result);
-                            if ((!isDsp && !isNote) ||
-                                (isDsp && gitHubDspRulesEnabled) ||
+                            if ((!isGitHub && !isNote) ||
+                                (isGitHub && gitHubRulesEnabled) ||
                                 (isNote && noteRulesEnabled)) {
                                 addResult(run.tool.driver.rules[result.ruleIndex], result);
                                 hasResults = true;
@@ -363,11 +363,10 @@
                 setToolbarEnabled(true);
             }
 
-            function isGitHubDspRule(rule) {
-                // Rules in the range SARIF2017-SARIF2025 are used to validate SARIF files intended
-                // for upload to the GitHub Developer Security Portal (DSP).
-                const ruleNumber = rule.id.substring(5)
-                return ruleNumber >= 2017 && ruleNumber <= 2025;
+            function isGitHubRule(rule) {
+                // Rules whose ids begin with "GH" are used to validate SARIF files intended
+                // for upload to GitHub Advanced Security code scanning.
+                return rule.id.startsWith('GH');
             }
 
             function isNoteResult(result) {

--- a/src/SarifWeb/packages.config
+++ b/src/SarifWeb/packages.config
@@ -30,8 +30,9 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="popper.js" version="1.14.0" targetFramework="net461" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
-  <package id="Sarif.Multitool" version="2.3.4" targetFramework="net461" />
-  <package id="Sarif.Sdk" version="2.3.4" targetFramework="net461" />
+  <package id="Sarif.Multitool" version="2.3.6" targetFramework="net461" />
+  <package id="Sarif.Multitool.Library" version="2.3.6" targetFramework="net461" />
+  <package id="Sarif.Sdk" version="2.3.6" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net461" />
   <package id="WebGrease" version="1.5.2" targetFramework="net452" />


### PR DESCRIPTION
This change is requested by the GitHub team. It changes the "branding" of the thing they internally refer to as "DSP" (Developer Security Portal) to the official name, "GitHub Advanced Security code scanning".

Also, we upgrade to the latest SARIF SDK and Multitool. In the latest version, we've factored the Multitool into a DotNetTool package (Sarif.Multitool) and a dependency package (Sarif.Multitool.Library). We need to bring in the library package because that's where the SARIF validator configuration file (which turns on the GitHub validation rules) lives.