### PR TITLE
Fix #119: Online validator doesn't report all results

### DIFF
--- a/src/SarifWeb/Controllers/ValidationController.cs
+++ b/src/SarifWeb/Controllers/ValidationController.cs
@@ -22,13 +22,12 @@ namespace SarifWeb.Controllers
 
         public ValidationController()
         {
-            string validationToolDirectory = HostingHelper.ValidationToolDirectory;
-            string postedFilesDirectory = HostingHelper.PostedFilesDirectory;
-
-            IFileSystem fileSystem = new FileSystem();
-            IProcessRunner processRunner = new ProcessRunner();
-
-            _validationService = new ValidationService(postedFilesDirectory, validationToolDirectory, fileSystem, processRunner);
+            _validationService = new ValidationService(
+                HostingHelper.PostedFilesDirectory,
+                HostingHelper.ValidationToolDirectory,
+                HostingHelper.PolicyFilesDirectory,
+                new FileSystem(),
+                new ProcessRunner());
         }
 
         public async Task<ValidationResponse> Post([FromBody] ValidationRequest validationRequest)

--- a/src/SarifWeb/SarifWeb.csproj
+++ b/src/SarifWeb/SarifWeb.csproj
@@ -229,6 +229,9 @@
     <Content Include="Images\Screenshots\WebViewerB.png" />
     <Content Include="Images\Screenshots\WebViewerB.thumbnail.png" />
     <Content Include="Images\triskelion.png" />
+    <Content Include="policies\allRules.config.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Scripts\ace\ace.js" />
     <Content Include="Scripts\ace\ext-beautify.js" />
     <Content Include="Scripts\ace\ext-elastic_tabstops_lite.js" />

--- a/src/SarifWeb/Services/ValidationService.cs
+++ b/src/SarifWeb/Services/ValidationService.cs
@@ -22,10 +22,11 @@ namespace SarifWeb.Services
         private const string ToolExeName = "Sarif.Multitool.exe";
         private const string ValidationLogSuffix = ".validation.sarif";
         private const string SchemaFileName = "sarif-schema.json";
+        private const string PolicyFileName = "allRules.config.xml";
 
         private readonly string _postedFilesDirectory;
-        private readonly string _multitoolDirectory;
         private readonly string _multitoolExePath;
+        private readonly string _policyFilesDirectory;
         private readonly string _schemaFilePath;
         private readonly IFileSystem _fileSystem;
         private readonly IProcessRunner _processRunner;
@@ -33,13 +34,14 @@ namespace SarifWeb.Services
         public ValidationService(
             string postedFilesDirectory,
             string multitoolDirectory,
+            string policyFilesDirectory,
             IFileSystem fileSystem,
             IProcessRunner processRunner)
         {
             _postedFilesDirectory = postedFilesDirectory;
-            _multitoolDirectory = multitoolDirectory;
             _multitoolExePath = Path.Combine(multitoolDirectory, ToolExeName);
             _schemaFilePath = Path.Combine(multitoolDirectory, SchemaFileName);
+            _policyFilesDirectory = policyFilesDirectory;
             _fileSystem = fileSystem;
             _processRunner = processRunner;
         }
@@ -49,9 +51,9 @@ namespace SarifWeb.Services
             string inputFilePath = Path.Combine(_postedFilesDirectory, validationRequest.SavedFileName);
             string outputFileName = Path.GetFileNameWithoutExtension(validationRequest.PostedFileName) + ValidationLogSuffix;
             string outputFilePath = Path.Combine(_postedFilesDirectory, outputFileName);
-            string gitHubConfigFilePath = Path.Combine(_multitoolDirectory, "policies", "github.config.xml");
+            string configFilePath = Path.Combine(_policyFilesDirectory, PolicyFileName);
 
-            string arguments = $"validate --output \"{outputFilePath}\" --json-schema \"{_schemaFilePath}\" --force --pretty-print --verbose --config \"{gitHubConfigFilePath}\" --rich-return-code \"{inputFilePath}\"";
+            string arguments = $"validate --output \"{outputFilePath}\" --json-schema \"{_schemaFilePath}\" --force --pretty-print --verbose --config \"{configFilePath}\" --rich-return-code \"{inputFilePath}\"";
 
             ValidationResponse validationResponse;
             try

--- a/src/SarifWeb/Utilities/HostingHelper.cs
+++ b/src/SarifWeb/Utilities/HostingHelper.cs
@@ -9,6 +9,7 @@ namespace SarifWeb.Utilities
 
         public static string ValidationToolDirectory =>
             HostingEnvironment.MapPath("~/bin/Sarif.Multitool");
+
         public static string PolicyFilesDirectory =>
             HostingEnvironment.MapPath("~/bin/policies");
     }

--- a/src/SarifWeb/Utilities/HostingHelper.cs
+++ b/src/SarifWeb/Utilities/HostingHelper.cs
@@ -9,5 +9,7 @@ namespace SarifWeb.Utilities
 
         public static string ValidationToolDirectory =>
             HostingEnvironment.MapPath("~/bin/Sarif.Multitool");
+        public static string PolicyFilesDirectory =>
+            HostingEnvironment.MapPath("~/bin/policies");
     }
 }

--- a/src/SarifWeb/policies/allRules.config.xml
+++ b/src/SarifWeb/policies/allRules.config.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Properties>
+  <Properties Key='GH1001.ProvideRequiredLocationProperties.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+  <Properties Key='GH1002.InlineThreadFlowLocations.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+  <Properties Key='GH1003.ProvideRequiredRegionProperties.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+  <Properties Key='GH1004.ReviewArraysThatExceedConfigurableDefaults.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+  <Properties Key='GH1005.LocationsMustBeRelativeUrisOrFilePaths.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+  <Properties Key='GH1006.ProvideCheckoutPath.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+</Properties>


### PR DESCRIPTION
The problem is that the web site runs the validator with `--config github.config.xml`, which it gets from the SARIF SDK. But that config is intended to be used when _the only thing you care about is that GitHub will accept your SARIF_. As such, it _disables_ many of the note-level rules.

The fix is to use a web-site-specific configuration file that turns on the GitHub rules without turning off any other rules.