### PR TITLE
Fix #119: Online validator does not display all results

### DIFF
--- a/src/SarifWeb.UITests/TestData/Test.sarif
+++ b/src/SarifWeb.UITests/TestData/Test.sarif
@@ -16,7 +16,7 @@
       },
       "versionControlProvenance": [
         {
-          "repositoryUri": "https://example.com/repos/my-repo/",
+          "repositoryUri": "https://github.com/microsoft/sarif-sdk/",
           "mappedTo": {
             "uriBaseId": "REPO_ROOT"
           }

--- a/src/SarifWeb.UITests/TestData/Test.sarif
+++ b/src/SarifWeb.UITests/TestData/Test.sarif
@@ -5,7 +5,13 @@
     {
       "tool": {
         "driver": {
-          "name": "SarifWeb UI Tests"
+          "name": "SarifWeb UI Tests",
+          "rules": [
+            {
+              "id": "TEST1001",
+              "name": "FriendlyName1"
+            }
+          ]
         }
       },
       "results": [

--- a/src/SarifWeb.UITests/TestData/Test.sarif
+++ b/src/SarifWeb.UITests/TestData/Test.sarif
@@ -14,6 +14,14 @@
           ]
         }
       },
+      "versionControlProvenance": [
+        {
+          "repositoryUri": "https://example.com/repos/my-repo/",
+          "mappedTo": {
+            "uriBaseId": "REPO_ROOT"
+          }
+        }
+      ],
       "results": [
         {
           "ruleId": "TEST1001",
@@ -25,7 +33,16 @@
           "ruleId": "TEST1002",
           "message": {
             "text": "Second result"
-          }
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "not-repo-relative.c"
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/src/SarifWeb.UITests/ValidationPageTests.cs
+++ b/src/SarifWeb.UITests/ValidationPageTests.cs
@@ -29,26 +29,22 @@ namespace SarifWeb.UITests
 
             // The following explicit counts should be obtained by running the Multitool library's
             // ValidateCommand against the test file.
-            //
-            // The counts are also wrong, because of https://github.com/microsoft/sarif-website/issues/119,
-            // "Online validator doesn't report all results". When we fix that bug, this test will
-            // "break" and we'll need to fix it.
-            page.NumResults.Should().Be(0);
-            page.CurrentResultIndex.Should().Be(0);
-
-            page.ClickAdditionalSuggestions();
-
-            page.NumResults.Should().Be(0);
-            page.CurrentResultIndex.Should().Be(0);
-
-            page.ClickGitHubRules();
-
             page.NumResults.Should().Be(2);
             page.CurrentResultIndex.Should().Be(1);
 
             page.ClickAdditionalSuggestions();
 
-            page.NumResults.Should().Be(2);
+            page.NumResults.Should().Be(5);
+            page.CurrentResultIndex.Should().Be(1);
+
+            page.ClickGitHubRules();
+
+            page.NumResults.Should().Be(7);
+            page.CurrentResultIndex.Should().Be(1);
+
+            page.ClickAdditionalSuggestions();
+
+            page.NumResults.Should().Be(4);
             page.CurrentResultIndex.Should().Be(1);
         }
     }

--- a/src/SarifWeb.UITests/ValidationPageTests.cs
+++ b/src/SarifWeb.UITests/ValidationPageTests.cs
@@ -34,12 +34,12 @@ namespace SarifWeb.UITests
 
             page.ClickAdditionalSuggestions();
 
-            page.NumResults.Should().Be(5);
+            page.NumResults.Should().Be(6);
             page.CurrentResultIndex.Should().Be(1);
 
             page.ClickGitHubRules();
 
-            page.NumResults.Should().Be(7);
+            page.NumResults.Should().Be(8);
             page.CurrentResultIndex.Should().Be(1);
 
             page.ClickAdditionalSuggestions();

--- a/src/SarifWeb.UITests/ValidationPageTests.cs
+++ b/src/SarifWeb.UITests/ValidationPageTests.cs
@@ -29,22 +29,22 @@ namespace SarifWeb.UITests
 
             // The following explicit counts should be obtained by running the Multitool library's
             // ValidateCommand against the test file.
-            page.NumResults.Should().Be(2);
+            page.NumResults.Should().Be(3);
             page.CurrentResultIndex.Should().Be(1);
 
             page.ClickAdditionalSuggestions();
 
-            page.NumResults.Should().Be(6);
+            page.NumResults.Should().Be(7);
             page.CurrentResultIndex.Should().Be(1);
 
             page.ClickGitHubRules();
 
-            page.NumResults.Should().Be(8);
+            page.NumResults.Should().Be(9);
             page.CurrentResultIndex.Should().Be(1);
 
             page.ClickAdditionalSuggestions();
 
-            page.NumResults.Should().Be(4);
+            page.NumResults.Should().Be(5);
             page.CurrentResultIndex.Should().Be(1);
         }
     }

--- a/src/SarifWeb.UITests/ValidationPageTests.cs
+++ b/src/SarifWeb.UITests/ValidationPageTests.cs
@@ -34,17 +34,17 @@ namespace SarifWeb.UITests
 
             page.ClickAdditionalSuggestions();
 
-            page.NumResults.Should().Be(7);
+            page.NumResults.Should().Be(6);
             page.CurrentResultIndex.Should().Be(1);
 
             page.ClickGitHubRules();
 
-            page.NumResults.Should().Be(9);
+            page.NumResults.Should().Be(8);
             page.CurrentResultIndex.Should().Be(1);
 
             page.ClickAdditionalSuggestions();
 
-            page.NumResults.Should().Be(5);
+            page.NumResults.Should().Be(6);
             page.CurrentResultIndex.Should().Be(1);
         }
     }

--- a/src/SarifWeb/Controllers/ValidationController.cs
+++ b/src/SarifWeb/Controllers/ValidationController.cs
@@ -22,13 +22,12 @@ namespace SarifWeb.Controllers
 
         public ValidationController()
         {
-            string validationToolDirectory = HostingHelper.ValidationToolDirectory;
-            string postedFilesDirectory = HostingHelper.PostedFilesDirectory;
-
-            IFileSystem fileSystem = new FileSystem();
-            IProcessRunner processRunner = new ProcessRunner();
-
-            _validationService = new ValidationService(postedFilesDirectory, validationToolDirectory, fileSystem, processRunner);
+            _validationService = new ValidationService(
+                HostingHelper.PostedFilesDirectory,
+                HostingHelper.ValidationToolDirectory,
+                HostingHelper.PolicyFilesDirectory,
+                new FileSystem(),
+                new ProcessRunner());
         }
 
         public async Task<ValidationResponse> Post([FromBody] ValidationRequest validationRequest)

--- a/src/SarifWeb/SarifWeb.csproj
+++ b/src/SarifWeb/SarifWeb.csproj
@@ -229,6 +229,9 @@
     <Content Include="Images\Screenshots\WebViewerB.png" />
     <Content Include="Images\Screenshots\WebViewerB.thumbnail.png" />
     <Content Include="Images\triskelion.png" />
+    <Content Include="policies\allRules.config.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Scripts\ace\ace.js" />
     <Content Include="Scripts\ace\ext-beautify.js" />
     <Content Include="Scripts\ace\ext-elastic_tabstops_lite.js" />

--- a/src/SarifWeb/Services/ValidationService.cs
+++ b/src/SarifWeb/Services/ValidationService.cs
@@ -22,10 +22,11 @@ namespace SarifWeb.Services
         private const string ToolExeName = "Sarif.Multitool.exe";
         private const string ValidationLogSuffix = ".validation.sarif";
         private const string SchemaFileName = "sarif-schema.json";
+        private const string PolicyFileName = "allRules.config.xml";
 
         private readonly string _postedFilesDirectory;
-        private readonly string _multitoolDirectory;
         private readonly string _multitoolExePath;
+        private readonly string _policyFilesDirectory;
         private readonly string _schemaFilePath;
         private readonly IFileSystem _fileSystem;
         private readonly IProcessRunner _processRunner;
@@ -33,13 +34,14 @@ namespace SarifWeb.Services
         public ValidationService(
             string postedFilesDirectory,
             string multitoolDirectory,
+            string policyFilesDirectory,
             IFileSystem fileSystem,
             IProcessRunner processRunner)
         {
             _postedFilesDirectory = postedFilesDirectory;
-            _multitoolDirectory = multitoolDirectory;
             _multitoolExePath = Path.Combine(multitoolDirectory, ToolExeName);
             _schemaFilePath = Path.Combine(multitoolDirectory, SchemaFileName);
+            _policyFilesDirectory = policyFilesDirectory;
             _fileSystem = fileSystem;
             _processRunner = processRunner;
         }
@@ -49,9 +51,9 @@ namespace SarifWeb.Services
             string inputFilePath = Path.Combine(_postedFilesDirectory, validationRequest.SavedFileName);
             string outputFileName = Path.GetFileNameWithoutExtension(validationRequest.PostedFileName) + ValidationLogSuffix;
             string outputFilePath = Path.Combine(_postedFilesDirectory, outputFileName);
-            string gitHubConfigFilePath = Path.Combine(_multitoolDirectory, "policies", "github.config.xml");
+            string configFilePath = Path.Combine(_policyFilesDirectory, PolicyFileName);
 
-            string arguments = $"validate --output \"{outputFilePath}\" --json-schema \"{_schemaFilePath}\" --force --pretty-print --verbose --config \"{gitHubConfigFilePath}\" --rich-return-code \"{inputFilePath}\"";
+            string arguments = $"validate --output \"{outputFilePath}\" --json-schema \"{_schemaFilePath}\" --force --pretty-print --verbose --config \"{configFilePath}\" --rich-return-code \"{inputFilePath}\"";
 
             ValidationResponse validationResponse;
             try

--- a/src/SarifWeb/Utilities/HostingHelper.cs
+++ b/src/SarifWeb/Utilities/HostingHelper.cs
@@ -9,5 +9,8 @@ namespace SarifWeb.Utilities
 
         public static string ValidationToolDirectory =>
             HostingEnvironment.MapPath("~/bin/Sarif.Multitool");
+
+        public static string PolicyFilesDirectory =>
+            HostingEnvironment.MapPath("~/bin/policies");
     }
 }

--- a/src/SarifWeb/Views/ValidationUi/Index.cshtml
+++ b/src/SarifWeb/Views/ValidationUi/Index.cshtml
@@ -318,6 +318,7 @@
                 if (run.results && run.results.length > 0) {
                     let hasResults = false;
                     if (run.tool && run.tool.driver && run.tool.driver.rules) {
+                        adjustRuleLevelsForGitHub(run.results, gitHubRulesEnabled);
                         $.each(run.results, function (index, result) {
                             const rule = run.tool.driver.rules[result.ruleIndex];
                             const isGitHub = isGitHubRule(rule);
@@ -361,6 +362,25 @@
                 }
 
                 setToolbarEnabled(true);
+            }
+
+            // This function is a temporary workaround for the fact that we don't yet
+            // have an API that adjusts and filters results by a policy. We happen to
+            // know that when the "GitHub" checkbox is checked, results for rule
+            // SARIF2007.ExpressPathsRelativeToRepoRoot should be treated as errors
+            // rather than warnings, and results for rule SARIF2012.ProvideHelpUris
+            // should be treated as warnings rather than notes.
+            function adjustRuleLevelsForGitHub(results, gitHubRulesEnabled) {
+                $.each(results, function (index, result) {
+                    switch (result.ruleId) {
+                        case 'SARIF2007':
+                            result.level = gitHubRulesEnabled ? "error" : "warning";
+                            break;
+                        case 'SARIF2012':
+                            result.level = gitHubRulesEnabled ? "warning" : "note";
+                            break;
+                    }
+                });
             }
 
             function isGitHubRule(rule) {

--- a/src/SarifWeb/policies/allRules.config.xml
+++ b/src/SarifWeb/policies/allRules.config.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Properties>
+  <Properties Key='GH1001.ProvideRequiredLocationProperties.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+  <Properties Key='GH1002.InlineThreadFlowLocations.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+  <Properties Key='GH1003.ProvideRequiredRegionProperties.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+  <Properties Key='GH1004.ReviewArraysThatExceedConfigurableDefaults.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+  <Properties Key='GH1005.LocationsMustBeRelativeUrisOrFilePaths.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+  <Properties Key='GH1006.ProvideCheckoutPath.Options'>
+    <Property Key='RuleEnabled' Value='Error' />
+  </Properties>
+</Properties>


### PR DESCRIPTION
Until the SDK offers an API to apply policy _post hoc_ to a comprehensive results, we implement the GitHub policy by using a private policy file that turns on the GitHub rules without doing anything else. Since there is no API for post-processing a results list per a policy, we temporarily adjust by hand the levels of the two rules affected by the GitHub policy: `SARIF2007.ExpressPathsRelativeToRepoRoot` elevates from warning to error, and `SARIF2012.ProvideHelpUris` elevates from note to warning.