### PR TITLE
Fixing ` Missing X-Frame-Options HTTP header` reported by CodeQL

### DIFF
--- a/src/SarifWeb/Web.config
+++ b/src/SarifWeb/Web.config
@@ -6,5 +6,10 @@
         <requestLimits maxAllowedContentLength="1073741824" />
       </requestFiltering>
     </security>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
 </configuration>

--- a/src/SarifWeb/Web.config
+++ b/src/SarifWeb/Web.config
@@ -8,7 +8,7 @@
     </security>
     <httpProtocol>
       <customHeaders>
-        <add name="X-Frame-Options" value="SAMEORIGIN" />
+        <add name="X-Frame-Options" value="DENY" />
       </customHeaders>
     </httpProtocol>
   </system.webServer>


### PR DESCRIPTION
This PR will fix the issue [Missing X-Frame-Options HTTP header](https://github.com/microsoft/sarif-website/security/code-scanning/23) reported by CodeQL.
