### PR TITLE
Removing disabled tag from inputs

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,0 +1,5 @@
+# Release History
+
+## Unreleased
+
+- FEATURE: Users are able to opt-in for additional checks before submitting a SARIF file. [#139](https://github.com/microsoft/sarif-website/pull/139)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,4 +2,6 @@
 
 ## Unreleased
 
-- FEATURE: Users are able to opt-in for additional checks before submitting a SARIF file. [#139](https://github.com/microsoft/sarif-website/pull/139)
+- BUG: Users now can select the 'additional suggestsions' and 'GitHub ingestion rules' checkboxes in advance of validation. Previously, these additional checks would have been run in any case. [#139](https://github.com/microsoft/sarif-website/pull/139)
+- Bump Sarif.Multitool.Library from 2.4.12 to 2.4.14. [#139](https://github.com/microsoft/sarif-website/pull/139)
+- Bump Microsoft.ApplicationInsights.AspNetCore from 2.19.0 to 2.20.0. [#139](https://github.com/microsoft/sarif-website/pull/139)

--- a/src/SarifWeb/Program.cs
+++ b/src/SarifWeb/Program.cs
@@ -1,11 +1,5 @@
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SarifWeb
 {

--- a/src/SarifWeb/SarifWeb.csproj
+++ b/src/SarifWeb/SarifWeb.csproj
@@ -42,8 +42,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
-    <PackageReference Include="Sarif.Multitool.Library" Version="2.4.12" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
+    <PackageReference Include="Sarif.Multitool.Library" Version="2.4.13" />
   </ItemGroup>
 
 </Project>

--- a/src/SarifWeb/Startup.cs
+++ b/src/SarifWeb/Startup.cs
@@ -1,14 +1,9 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SarifWeb.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SarifWeb
 {

--- a/src/SarifWeb/Views/Validation/Index.cshtml
+++ b/src/SarifWeb/Views/Validation/Index.cshtml
@@ -63,7 +63,7 @@
                 <button id="utilitiesButton" aria-label="Utilities menu" title="Utilities menu" class="toolbar-button" disabled>
                     <span class="ui-icon ui-icon-gear">icon</span>
                 </button>
-                <div id="ruleFilters" no-disable>
+                <div id="ruleFilters" no-data-disabled>
                     <input type="checkbox" id="noteRules" aria-labelledby="noteRulesLabel" title="More ways to improve your SARIF files." />
                     <label id="noteRulesLabel" for="noteRules" class="ui-widget">Additional suggestions</label>
                     <br />

--- a/src/SarifWeb/Views/Validation/Index.cshtml
+++ b/src/SarifWeb/Views/Validation/Index.cshtml
@@ -64,10 +64,10 @@
                     <span class="ui-icon ui-icon-gear">icon</span>
                 </button>
                 <div id="ruleFilters">
-                    <input type="checkbox" id="noteRules" aria-labelledby="noteRulesLabel" title="More ways to improve your SARIF files." disabled />
+                    <input type="checkbox" id="noteRules" aria-labelledby="noteRulesLabel" checked="checked" title="More ways to improve your SARIF files." disabled />
                     <label id="noteRulesLabel" for="noteRules" class="ui-widget">Additional suggestions</label>
                     <br />
-                    <input type="checkbox" id="gitHubRules" aria-labelledby="gitHubRulesLabel" title="Requirements for SARIF files uploaded to GitHub Advanced Security code scanning." disabled />
+                    <input type="checkbox" id="gitHubRules" aria-labelledby="gitHubRulesLabel" checked="checked" title="Requirements for SARIF files uploaded to GitHub Advanced Security code scanning." disabled />
                     <label id="gitHubRulesLabel" for="gitHubRules" class="ui-widget">GitHub ingestion rules</label>
                 </div>
             </div>

--- a/src/SarifWeb/Views/Validation/Index.cshtml
+++ b/src/SarifWeb/Views/Validation/Index.cshtml
@@ -63,7 +63,7 @@
                 <button id="utilitiesButton" aria-label="Utilities menu" title="Utilities menu" class="toolbar-button" disabled>
                     <span class="ui-icon ui-icon-gear">icon</span>
                 </button>
-                <div id="ruleFilters">
+                <div id="ruleFilters" no-disable>
                     <input type="checkbox" id="noteRules" aria-labelledby="noteRulesLabel" title="More ways to improve your SARIF files." />
                     <label id="noteRulesLabel" for="noteRules" class="ui-widget">Additional suggestions</label>
                     <br />

--- a/src/SarifWeb/Views/Validation/Index.cshtml
+++ b/src/SarifWeb/Views/Validation/Index.cshtml
@@ -38,12 +38,12 @@
 
 <section id="validatorSection" role="region" aria-labelledby="pageTitle" class="content-section gray-section">
     <div id="validatorContainer">
-        <div id="validatorToolbar" data-disabled>
+        <div id="validatorToolbar">
             <div id="leftToolbarGroup">
-                <select id="ruleList" role="combobox" aria-label="Rule list" multiple size="1" disabled>
+                <select id="ruleList" role="combobox" aria-label="Rule list" multiple size="1">
                     <option value=""></option>
                 </select>
-                <button id="prevResultButton" aria-label="Previous result" title="Previous result" class="toolbar-button" disabled>
+                <button id="prevResultButton" aria-label="Previous result" title="Previous result" class="toolbar-button">
                     <span class="ui-icon ui-icon-caret-1-n">icon</span>
                 </button>
                 <div id="resultPosition">
@@ -51,23 +51,23 @@
                     <div id="resultPositionSeparator" aria-label="of">/</div>
                     <div id="resultPositionCount">0</div>
                 </div>
-                <button id="nextResultButton" aria-label="Next result" title="Next result" class="toolbar-button" disabled>
+                <button id="nextResultButton" aria-label="Next result" title="Next result" class="toolbar-button">
                     <span class="ui-icon ui-icon-caret-1-s">icon</span>
                 </button>
                 <div id="ruleDescription"></div>
             </div>
             <div id="rightToolbarGroup">
-                <button id="revalidateButton" aria-label="Re-validate log file" title="Re-validate log file" class="toolbar-button" disabled>
+                <button id="revalidateButton" aria-label="Re-validate log file" title="Re-validate log file" class="toolbar-button">
                     <span class="ui-icon ui-icon-arrowrefresh-1-e">icon</span>
                 </button>
-                <button id="utilitiesButton" aria-label="Utilities menu" title="Utilities menu" class="toolbar-button" disabled>
+                <button id="utilitiesButton" aria-label="Utilities menu" title="Utilities menu" class="toolbar-button">
                     <span class="ui-icon ui-icon-gear">icon</span>
                 </button>
                 <div id="ruleFilters">
-                    <input type="checkbox" id="noteRules" aria-labelledby="noteRulesLabel" checked="checked" title="More ways to improve your SARIF files." disabled />
+                    <input type="checkbox" id="noteRules" aria-labelledby="noteRulesLabel" title="More ways to improve your SARIF files." />
                     <label id="noteRulesLabel" for="noteRules" class="ui-widget">Additional suggestions</label>
                     <br />
-                    <input type="checkbox" id="gitHubRules" aria-labelledby="gitHubRulesLabel" checked="checked" title="Requirements for SARIF files uploaded to GitHub Advanced Security code scanning." disabled />
+                    <input type="checkbox" id="gitHubRules" aria-labelledby="gitHubRulesLabel" title="Requirements for SARIF files uploaded to GitHub Advanced Security code scanning." />
                     <label id="gitHubRulesLabel" for="gitHubRules" class="ui-widget">GitHub ingestion rules</label>
                 </div>
             </div>
@@ -306,7 +306,6 @@
                 clearRuleList();
                 setResultPositionText(0, 0);
                 setResultLocationDetails();
-                setToolbarEnabled(false);
                 clearLineMarkers();
                 clearGutterDecoration();
                 currentResultLocationIndex = -1;
@@ -360,8 +359,6 @@
                         }
                     }
                 }
-
-                setToolbarEnabled(true);
             }
 
             // This function is a temporary workaround for the fact that we don't yet
@@ -495,7 +492,6 @@
                     editor.selection.clearSelection();
 
                     // Enable controls
-                    setToolbarEnabled(true);
                     resolve();
                 });
             }
@@ -510,30 +506,8 @@
                 }
 
                 clearRuleList();
-                setToolbarEnabled(false);
                 setResultPositionText(0, 0);
                 setResultLocationDetails();
-            }
-
-            function setToolbarEnabled(enable) {
-                let verb;
-                let selector = "";
-
-                if (enable) {
-                    verb = "enable";
-                    selector = ":disabled";
-                    $toolbar.removeAttr("data-disabled");
-                } else {
-                    verb = "disable";
-                    $toolbar.attr("data-disabled");
-                }
-
-                $("#validatorToolbar .toolbar-button" + selector).each(function (index, button) {
-                    $(button).button(verb);
-                });
-                $ruleList.multiselect(verb);
-                let ruleFilterControls = $("#ruleFilters > *");
-                ruleFilterControls.attr("disabled", !enable);
             }
 
             function clearRuleList() {

--- a/src/SarifWeb/Views/Validation/Index.cshtml
+++ b/src/SarifWeb/Views/Validation/Index.cshtml
@@ -38,12 +38,12 @@
 
 <section id="validatorSection" role="region" aria-labelledby="pageTitle" class="content-section gray-section">
     <div id="validatorContainer">
-        <div id="validatorToolbar">
+        <div id="validatorToolbar" data-disabled>
             <div id="leftToolbarGroup">
-                <select id="ruleList" role="combobox" aria-label="Rule list" multiple size="1">
+                <select id="ruleList" role="combobox" aria-label="Rule list" multiple size="1" disabled>
                     <option value=""></option>
                 </select>
-                <button id="prevResultButton" aria-label="Previous result" title="Previous result" class="toolbar-button">
+                <button id="prevResultButton" aria-label="Previous result" title="Previous result" class="toolbar-button" disabled>
                     <span class="ui-icon ui-icon-caret-1-n">icon</span>
                 </button>
                 <div id="resultPosition">
@@ -51,16 +51,16 @@
                     <div id="resultPositionSeparator" aria-label="of">/</div>
                     <div id="resultPositionCount">0</div>
                 </div>
-                <button id="nextResultButton" aria-label="Next result" title="Next result" class="toolbar-button">
+                <button id="nextResultButton" aria-label="Next result" title="Next result" class="toolbar-button" disabled>
                     <span class="ui-icon ui-icon-caret-1-s">icon</span>
                 </button>
                 <div id="ruleDescription"></div>
             </div>
             <div id="rightToolbarGroup">
-                <button id="revalidateButton" aria-label="Re-validate log file" title="Re-validate log file" class="toolbar-button">
+                <button id="revalidateButton" aria-label="Re-validate log file" title="Re-validate log file" class="toolbar-button" disabled>
                     <span class="ui-icon ui-icon-arrowrefresh-1-e">icon</span>
                 </button>
-                <button id="utilitiesButton" aria-label="Utilities menu" title="Utilities menu" class="toolbar-button">
+                <button id="utilitiesButton" aria-label="Utilities menu" title="Utilities menu" class="toolbar-button" disabled>
                     <span class="ui-icon ui-icon-gear">icon</span>
                 </button>
                 <div id="ruleFilters">
@@ -306,6 +306,7 @@
                 clearRuleList();
                 setResultPositionText(0, 0);
                 setResultLocationDetails();
+                setToolbarEnabled(false);
                 clearLineMarkers();
                 clearGutterDecoration();
                 currentResultLocationIndex = -1;
@@ -359,6 +360,8 @@
                         }
                     }
                 }
+
+                setToolbarEnabled(true);
             }
 
             // This function is a temporary workaround for the fact that we don't yet
@@ -492,6 +495,7 @@
                     editor.selection.clearSelection();
 
                     // Enable controls
+                    setToolbarEnabled(true);
                     resolve();
                 });
             }
@@ -506,8 +510,28 @@
                 }
 
                 clearRuleList();
+                setToolbarEnabled(false);
                 setResultPositionText(0, 0);
                 setResultLocationDetails();
+            }
+
+            function setToolbarEnabled(enable) {
+                let verb;
+                let selector = "";
+
+                if (enable) {
+                    verb = "enable";
+                    selector = ":disabled";
+                    $toolbar.removeAttr("data-disabled");
+                } else {
+                    verb = "disable";
+                    $toolbar.attr("data-disabled");
+                }
+
+                $("#validatorToolbar .toolbar-button" + selector).each(function (index, button) {
+                    $(button).button(verb);
+                });
+                $ruleList.multiselect(verb);
             }
 
             function clearRuleList() {

--- a/src/SarifWeb/wwwroot/css/Validator.css
+++ b/src/SarifWeb/wwwroot/css/Validator.css
@@ -31,6 +31,10 @@
     font-size: 20px;
 }
 
+#validatorToolbar *[no-disable] {
+    color: initial;
+}
+
 #leftToolbarGroup {
     align-items: flex-start;
     flex: 1;

--- a/src/SarifWeb/wwwroot/css/Validator.css
+++ b/src/SarifWeb/wwwroot/css/Validator.css
@@ -31,7 +31,7 @@
     font-size: 20px;
 }
 
-#validatorToolbar *[no-disable] {
+#validatorToolbar *[no-data-disabled] {
     color: initial;
 }
 


### PR DESCRIPTION
This change will remove the disabled tags for the web site checkboxes for 'additional suggestions' and 'github validations', allowing the user to enable it before uploading the SARIF file. Currently users must enable these after validating, which is confusing, as it's not clear whether the additional analysis has occurred or if validation will be repeated.