### PR TITLE
Migration to 1ES Templates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,33 +4,33 @@ pr:
 pool:
   vmImage: 'windows-latest'
 
-  resources:
-    repositories:
-      - repository: 1esPipelines
-        type: git
-        name: 1ESPipelineTemplates/1ESPipelineTemplates
-        ref: refs/tags/release
-  extends:
-      template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
-      parameters:
-        pool:
-          name: 1ES-Shared-Hosted-Pool_Windows-Server-2022
-          os: windows
-        containers:
-          default_windows_container:
-            image: mcr.microsoft.com/windows/servercore:ltsc2022
-          
-        stages:
-        - stage: build
-          jobs:
-          - job: build
-  
+resources:
+  repositories:
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+extends:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+    parameters:
+      pool:
+        name: 1ES-Shared-Hosted-Pool_Windows-Server-2022
+        os: windows
+      containers:
+        default_windows_container:
+          image: mcr.microsoft.com/windows/servercore:ltsc2022
+        
+      stages:
+      - stage: build
+        jobs:
+        - job: build
 
-            steps:
-            - task: DotNetCoreCLI@2
-              inputs:
-                command: 'build'
-                projects: src/SarifWeb.sln
-                configuration: 'Release'
 
-            - task: ComponentGovernanceComponentDetection@0
+          steps:
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: 'build'
+              projects: src/SarifWeb.sln
+              configuration: 'Release'
+
+          - task: ComponentGovernanceComponentDetection@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,16 +36,16 @@ extends:
               - output: pipelineArtifact
                 targetPath: $(System.DefaultWorkingDirectory)
 
-              steps:
-                - task: UseDotNet@2
-                  displayName: 'Use .NET Core sdk'
-                  inputs:
-                    packageType: sdk
-                    version: 5.0.x
-                - task: DotNetCoreCLI@2
-                  inputs:
-                    command: 'build'
-                    projects: src/SarifWeb.sln
-                    configuration: 'Release'
+            steps:
+              - task: UseDotNet@2
+                displayName: 'Use .NET Core sdk'
+                inputs:
+                  packageType: sdk
+                  version: 5.0.x
+              - task: DotNetCoreCLI@2
+                inputs:
+                  command: 'build'
+                  projects: src/SarifWeb.sln
+                  configuration: 'Release'
 
-                - task: ComponentGovernanceComponentDetection@0
+              - task: ComponentGovernanceComponentDetection@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,7 @@ extends:
               outputs:
               - output: pipelineArtifact
                 targetPath: $(System.DefaultWorkingDirectory)
+                artifactName: sarif-website
 
             steps:
               - task: UseDotNet@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,15 +37,15 @@ extends:
                 targetPath: $(System.DefaultWorkingDirectory)
 
               steps:
-              - task: UseDotNet@2
-                displayName: 'Use .NET Core sdk'
-                inputs:
-                  packageType: sdk
-                  version: 5.0.x
-              - task: DotNetCoreCLI@2
-                inputs:
-                  command: 'build'
-                  projects: src/SarifWeb.sln
-                  configuration: 'Release'
+                - task: UseDotNet@2
+                  displayName: 'Use .NET Core sdk'
+                  inputs:
+                    packageType: sdk
+                    version: 5.0.x
+                - task: DotNetCoreCLI@2
+                  inputs:
+                    command: 'build'
+                    projects: src/SarifWeb.sln
+                    configuration: 'Release'
 
-              - task: ComponentGovernanceComponentDetection@0
+                - task: ComponentGovernanceComponentDetection@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,9 +28,6 @@ extends:
         jobs:
           - job: build
             templateContext:
-              inputs:
-              - input: checkout
-                repository: self
               outputs:
               - output: pipelineArtifact
                 targetPath: $(System.DefaultWorkingDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,5 +47,3 @@ extends:
                   command: 'build'
                   projects: src/SarifWeb.sln
                   configuration: 'Release'
-
-              - task: ComponentGovernanceComponentDetection@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,3 +40,5 @@ extends:
               command: 'build'
               projects: src/SarifWeb.sln
               configuration: 'Release'
+
+          - task: ComponentGovernanceComponentDetection@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,26 +26,26 @@ extends:
       stages:
       - stage: build
         jobs:
-        - job: build
-        templateContext:
-          inputs:
-          - input: checkout
-            repository: self
-            displayName: build
-          outputs:
-          - output: pipelineArtifact
-            targetPath: $(System.DefaultWorkingDirectory)
+          - job: build
+            templateContext:
+              inputs:
+              - input: checkout
+                repository: self
+                displayName: build
+              outputs:
+              - output: pipelineArtifact
+                targetPath: $(System.DefaultWorkingDirectory)
 
-          steps:
-          - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
-            inputs:
-              packageType: sdk
-              version: 5.0.x
-          - task: DotNetCoreCLI@2
-            inputs:
-              command: 'build'
-              projects: src/SarifWeb.sln
-              configuration: 'Release'
+              steps:
+              - task: UseDotNet@2
+                displayName: 'Use .NET Core sdk'
+                inputs:
+                  packageType: sdk
+                  version: 5.0.x
+              - task: DotNetCoreCLI@2
+                inputs:
+                  command: 'build'
+                  projects: src/SarifWeb.sln
+                  configuration: 'Release'
 
-          - task: ComponentGovernanceComponentDetection@0
+              - task: ComponentGovernanceComponentDetection@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,5 +37,3 @@ extends:
               command: 'build'
               projects: src/SarifWeb.sln
               configuration: 'Release'
-
-          - task: ComponentGovernanceComponentDetection@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,11 @@ extends:
 
 
           steps:
-          
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core sdk'
+            inputs:
+              packageType: sdk
+              version: 5.0.x
           - task: DotNetCoreCLI@2
             inputs:
               command: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,6 @@ extends:
               inputs:
               - input: checkout
                 repository: self
-                displayName: build
               outputs:
               - output: pipelineArtifact
                 targetPath: $(System.DefaultWorkingDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,15 +27,7 @@ extends:
       - stage: build
         jobs:
         - job: build
-          templateContext:
-            inputs:
-            - input: checkout
-              repository: self
-              submodules: true
-            outputs:
-            - output: pipelineArtifact
-              targetPath: $(System.DefaultWorkingDirectory)/drop_sdl_sources
-              artifactName: CodeAnalysisLogs
+
 
           steps:
           - task: UseDotNet@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,15 @@ extends:
       - stage: build
         jobs:
         - job: build
-
+          templateContext:
+            inputs:
+            - input: checkout
+              repository: self
+              submodules: true
+            outputs:
+            - output: pipelineArtifact
+              targetPath: $(System.DefaultWorkingDirectory)/drop_sdl_sources
+              artifactName: CodeAnalysisLogs
 
           steps:
           - task: UseDotNet@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,14 @@ extends:
       - stage: build
         jobs:
         - job: build
-
+        templateContext:
+          inputs:
+          - input: checkout
+            repository: self
+            submodules: true
+          outputs:
+          - output: pipelineArtifact
+            targetPath: $(System.DefaultWorkingDirectory)
 
           steps:
           - task: UseDotNet@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,11 +4,33 @@ pr:
 pool:
   vmImage: 'windows-latest'
 
-steps:
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'build'
-    projects: src/SarifWeb.sln
-    configuration: 'Release'
+  resources:
+    repositories:
+      - repository: 1esPipelines
+        type: git
+        name: 1ESPipelineTemplates/1ESPipelineTemplates
+        ref: refs/tags/release
+  extends:
+      template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+      parameters:
+        pool:
+          name: 1ES-Shared-Hosted-Pool_Windows-Server-2022
+          os: windows
+        containers:
+          default_windows_container:
+            image: mcr.microsoft.com/windows/servercore:ltsc2022
+          
+        stages:
+        - stage: build
+          jobs:
+          - job: build
+  
 
-- task: ComponentGovernanceComponentDetection@0
+            steps:
+            - task: DotNetCoreCLI@2
+              inputs:
+                command: 'build'
+                projects: src/SarifWeb.sln
+                configuration: 'Release'
+
+            - task: ComponentGovernanceComponentDetection@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,11 @@ extends:
 
 
           steps:
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core sdk'
+            inputs:
+              packageType: sdk
+              version: 5.0.x
           - task: DotNetCoreCLI@2
             inputs:
               command: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ extends:
           inputs:
           - input: checkout
             repository: self
-            submodules: true
+            displayName: build
           outputs:
           - output: pipelineArtifact
             targetPath: $(System.DefaultWorkingDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,10 @@ extends:
         os: windows
       containers:
         default_windows_container:
-          image: mcr.microsoft.com/windows/servercore:ltsc2022
+          image: 1espipelinesdevpme.azurecr.io/windows/ltsc2022/vse2022:latest
+          registry: 1espipelinesdevpme.azurecr.io
+          tenantId: PME
+          identityType: 1ESPipelineIdentity
         
       stages:
       - stage: build
@@ -27,11 +30,7 @@ extends:
 
 
           steps:
-          - task: UseDotNet@2
-            displayName: 'Use .NET Core sdk'
-            inputs:
-              packageType: sdk
-              version: 5.0.x
+          
           - task: DotNetCoreCLI@2
             inputs:
               command: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,11 +34,7 @@ extends:
                 artifactName: sarif-website
 
             steps:
-              - task: UseDotNet@2
-                displayName: 'Use .NET Core sdk'
-                inputs:
-                  packageType: sdk
-                  version: 5.0.x
+              
               - task: DotNetCoreCLI@2
                 inputs:
                   command: 'build'


### PR DESCRIPTION
I have migrated the Microsoft SARIF website's code repo to 1ES compliance, the original code base can be seen [here](https://github.com/microsoft/sarif-website). A successful run of the new pipeline can be seen [here](https://dev.azure.com/mseng/1ES/_build/results?buildId=18235559&view=results). The original pipeline before I made these changes can be seen [here](https://dev.azure.com/mseng/1ES/_build/results?buildId=18235559&view=results).