### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @michaelcfanning @EasyRhinoMSFT @rwoll @cfaucon
+* @michaelcfanning @EasyRhinoMSFT @rwoll @cfaucon @shaopeng-gh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @michaelcfanning @EasyRhinoMSFT @marmegh @cfaucon
+* @michaelcfanning @EasyRhinoMSFT @rwoll @cfaucon


### PR DESCRIPTION
Remove Mary, add Ross
Eddy is not a code owner; presumably he was added to the other PR because he has contributed in the past.